### PR TITLE
Update build.gradle to version supported by current toolchain

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.0.0'
+        classpath 'com.android.tools.build:gradle:1.5.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
This fixes the sync issue (shown below) when you try to import the project and build it using the current/latest Android Studio toolchain.

![image](https://cloud.githubusercontent.com/assets/5368500/11491888/2ed079b4-983a-11e5-9989-8b0e82a7a5ce.png)
